### PR TITLE
create-instance instead of vm

### DIFF
--- a/src/app/dashboard/create-instance/page.tsx
+++ b/src/app/dashboard/create-instance/page.tsx
@@ -4,11 +4,11 @@ import { Sidebar } from "@/components/Sidebar";
 import { VM } from "@/components/VM";
 
 export const metadata: Metadata = {
-  title: "IConsole | Create VM",
+  title: "IConsole | Create Instance",
   description: "Create and deploy new virtual machine instances",
 };
 
-export default function VMPage() {
+export default function CreateInstancePage() {
   return (
     <div className="flex min-h-screen">
       <Sidebar />
@@ -16,7 +16,7 @@ export default function VMPage() {
         <div className="w-full p-4 sm:p-6 space-y-6">
           <div className="space-y-1">
             <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent select-none">
-              Create Virtual Machine
+              Create Instance
             </h1>
             <p className="text-muted-foreground">
               Deploy new virtual machine instances with custom configurations

--- a/src/app/dashboard/instances/page.tsx
+++ b/src/app/dashboard/instances/page.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from "@/components/Sidebar";
 
 export const metadata: Metadata = {
   title: "IConsole | Instances",
-  description: "Manage your virtual machine instances",
+  description: "Manage and create your virtual machine instances",
 };
 
 export default function InstancesPage() {
@@ -19,7 +19,7 @@ export default function InstancesPage() {
               Instances
             </h1>
             <p className="text-muted-foreground">
-              Manage and monitor your virtual machine instances
+              Manage, create, and monitor your virtual machine instances
             </p>
           </div>
           <Instances />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,7 +38,7 @@ const sidebarItems = [
 ];
 
 const collapsibleRoutes: Record<string, string[]> = {
-  compute: ["/dashboard/instances", "/dashboard/vm"],
+  compute: ["/dashboard/instances", "/dashboard/create-instance"],
 };
 
 export function Sidebar() {
@@ -214,13 +214,15 @@ export function Sidebar() {
                     <Button
                       variant="ghost"
                       className={`w-full justify-start h-9 px-3 cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-white
-                        ${pathname === "/dashboard/vm" ? "bg-slate-100 dark:bg-slate-800 font-bold text-slate-900 dark:text-white" : "text-slate-700 dark:text-slate-300"}`}
+                        ${pathname === "/dashboard/create-instance" ? "bg-slate-100 dark:bg-slate-800 font-bold text-slate-900 dark:text-white" : "text-slate-700 dark:text-slate-300"}`}
                       onClick={() => {
-                        router.push("/dashboard/vm");
+                        router.push("/dashboard/create-instance");
                       }}
                     >
                       <MonitorStop className="h-4 w-4 mr-3" />
-                      <span className="text-sm font-medium">VM</span>
+                      <span className="text-sm font-medium">
+                        Create Instance
+                      </span>
                     </Button>
                   </li>
                 </ul>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ export function middleware(request: NextRequest) {
   const protectedRoutes = [
     "/dashboard/overview",
     "/dashboard/instances",
-    "/dashboard/vm",
+    "/dashboard/create-instance",
     "/dashboard/images",
   ];
 


### PR DESCRIPTION
### TL;DR

Renamed the VM page to "Create Instance" for better clarity and consistency throughout the application.

### What changed?

- Renamed `/dashboard/vm` route to `/dashboard/create-instance`
- Updated page title from "Create Virtual Machine" to "Create Instance"
- Updated the sidebar navigation label from "VM" to "Create Instance"
- Updated the instances page description to include "create" functionality
- Updated protected routes in middleware to reflect the new path

### Why make this change?

This change improves terminology consistency across the application by using "Instance" instead of "VM" or "Virtual Machine". The new naming better aligns with cloud platform conventions and makes the purpose of the page clearer to users. The updated navigation label and route also better describe the actual functionality of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated terminology across the dashboard from "VM" or "Virtual Machine" to "Instance" for a more consistent user experience.
  * Sidebar navigation now displays "Create Instance" instead of "VM" and links to the updated creation page.

* **Documentation**
  * Enhanced page descriptions to clearly indicate that users can create, manage, and monitor instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->