### PR TITLE
fixed queries keyword

### DIFF
--- a/src/components/ProjectFormDialog.tsx
+++ b/src/components/ProjectFormDialog.tsx
@@ -89,7 +89,12 @@ export function ProjectFormDialog({
   const createMutation = useMutation({
     mutationFn: (data: ProjectCreateRequest) => ProjectService.create(data),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["projects", "details"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["auth", "projects"],
+      });
       toast.success("Project created successfully");
       onOpenChange(false);
       form.reset();
@@ -104,7 +109,12 @@ export function ProjectFormDialog({
     mutationFn: ({ id, ...data }: ProjectUpdateRequest & { id: string }) =>
       ProjectService.update(id, data),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["projects", "details"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["auth", "projects"],
+      });
       toast.success("Project updated successfully");
       onOpenChange(false);
       form.reset();

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -126,7 +126,12 @@ export function Projects() {
   const deleteMutation = useMutation({
     mutationFn: (projectId: string) => ProjectService.delete(projectId),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["projects", "details"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["auth", "projects"],
+      });
       toast.success("Project deleted successfully");
       setShowDeleteDialog(false);
       setProjectToDelete(undefined);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -89,7 +89,7 @@ export function Sidebar() {
   }, []);
 
   const { data: projects, isLoading: projectsLoading } = useQuery({
-    queryKey: ["projects"],
+    queryKey: ["auth", "projects"],
     queryFn: () => AuthService.getProjects(),
   });
 

--- a/src/components/UserManagementDialog.tsx
+++ b/src/components/UserManagementDialog.tsx
@@ -81,8 +81,12 @@ export function UserManagementDialog({
     mutationFn: (data: AssignUserToProjectRequest) =>
       ProjectService.assignUser(data),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
-      await queryClient.invalidateQueries({ queryKey: ["project-details"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["projects", "details"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["auth", "projects"],
+      });
       await queryClient.invalidateQueries({ queryKey: ["unassigned-users"] });
       toast.success("User assigned successfully");
       setSelectedUser("");
@@ -97,8 +101,12 @@ export function UserManagementDialog({
     mutationFn: (data: RemoveUserFromProjectRequest) =>
       ProjectService.removeUser(data),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
-      await queryClient.invalidateQueries({ queryKey: ["project-details"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["projects", "details"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["auth", "projects"],
+      });
       await queryClient.invalidateQueries({ queryKey: ["unassigned-users"] });
       toast.success("User removed successfully");
     },
@@ -111,8 +119,12 @@ export function UserManagementDialog({
     mutationFn: (data: UpdateUserRolesRequest) =>
       ProjectService.updateUserRoles(data),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
-      await queryClient.invalidateQueries({ queryKey: ["project-details"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["projects", "details"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["auth", "projects"],
+      });
       toast.success("User roles updated successfully");
       setEditingUser(undefined);
     },


### PR DESCRIPTION
### TL;DR

Updated React Query cache invalidation to use more specific query keys for project-related operations.

### What changed?

- Modified query key in `Sidebar.tsx` from `["projects"]` to `["auth", "projects"]` to better reflect the data source
- Updated cache invalidation in multiple components to target specific query keys:
  - Changed from generic `["projects"]` to more specific `["projects", "details"]` and `["auth", "projects"]`
  - Removed references to the deprecated `["project-details"]` query key
- This change affects project creation, updates, deletion, and user management operations

### Why make this change?

The previous implementation used overly generic query keys which could lead to unnecessary re-renders and potential stale data. By using more specific query keys that better represent the data structure, we improve cache management and ensure that only the relevant components re-render when data changes. This approach follows React Query best practices for granular cache invalidation.