### PR TITLE
sort imports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
+        "@ianvs/prettier-plugin-sort-imports": "^4.6.2",
         "@next/eslint-plugin-next": "^15.4.4",
         "@tailwindcss/postcss": "^4.0.15",
         "@tanstack/eslint-plugin-query": "^5.83.1",
@@ -57,7 +58,6 @@
         "eslint-plugin-unicorn": "^59.0.1",
         "postcss": "^8.5.3",
         "prettier": "^3.5.3",
-        "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^4.0.15",
         "tw-animate-css": "^1.3.6",
@@ -77,9 +77,21 @@
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/generator": ["@babel/generator@7.28.3", "", { "dependencies": { "@babel/parser": "^7.28.3", "@babel/types": "^7.28.2", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
+
+    "@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
+
+    "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "@babel/traverse": ["@babel/traverse@7.28.3", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.3", "@babel/template": "^7.27.2", "@babel/types": "^7.28.2", "debug": "^4.3.1" } }, "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ=="],
 
     "@babel/types": ["@babel/types@7.28.1", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ=="],
 
@@ -128,6 +140,8 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@ianvs/prettier-plugin-sort-imports": ["@ianvs/prettier-plugin-sort-imports@4.6.2", "", { "dependencies": { "@babel/generator": "^7.26.2", "@babel/parser": "^7.26.2", "@babel/traverse": "^7.25.9", "@babel/types": "^7.26.0", "semver": "^7.5.2" }, "peerDependencies": { "@prettier/plugin-oxc": "^0.0.4", "@vue/compiler-sfc": "2.7.x || 3.x", "content-tag": "^4.0.0", "prettier": "2 || 3 || ^4.0.0-0", "prettier-plugin-ember-template-tag": "^2.1.0" }, "optionalPeers": ["@prettier/plugin-oxc", "@vue/compiler-sfc", "content-tag", "prettier-plugin-ember-template-tag"] }, "sha512-kHiL1IghIodo43clNQaJJU2rPqXEioPG+Ink4/T5za46A0ggSNvIx4NM3hGgciQ2VpDaR/X8cTJIZDKRurWjPw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.0" }, "os": "darwin", "cpu": "arm64" }, "sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg=="],
 
@@ -933,7 +947,7 @@
 
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.0", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w=="],
 
-    "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.1.0", "", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0" }, "optionalPeers": ["vue-tsc"] }, "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A=="],
+    "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.2.0", "", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0 || 3" }, "optionalPeers": ["vue-tsc"] }, "sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg=="],
 
     "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.6.14", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-import-sort": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-style-order": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-import-sort", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-style-order", "prettier-plugin-svelte"] }, "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg=="],
 
@@ -989,7 +1003,7 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
@@ -1125,6 +1139,14 @@
 
     "zod": ["zod@4.0.5", "", {}, "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA=="],
 
+    "@babel/generator/@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
+    "@babel/parser/@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
+    "@babel/template/@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
+    "@babel/traverse/@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
@@ -1167,8 +1189,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
     "@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.39.0", "", { "dependencies": { "@typescript-eslint/types": "8.39.0", "@typescript-eslint/visitor-keys": "8.39.0" } }, "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A=="],
 
     "@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.38.0", "", {}, "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw=="],
@@ -1189,27 +1209,23 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "eslint-plugin-unicorn/@eslint/plugin-kit": ["@eslint/plugin-kit@0.2.8", "", { "dependencies": { "@eslint/core": "^0.13.0", "levn": "^0.4.1" } }, "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA=="],
 
     "eslint-plugin-unicorn/globals": ["globals@16.3.0", "", {}, "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ=="],
 
-    "eslint-plugin-unicorn/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "fdir/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
-
-    "global-agent/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
-    "is-bun-module/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
 
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
-
-    "sharp/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
@@ -1231,8 +1247,6 @@
 
     "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.38.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.38.0", "@typescript-eslint/types": "^8.38.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.38.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ=="],
@@ -1240,8 +1254,6 @@
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1281,8 +1293,6 @@
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
     "@typescript-eslint/parser/@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -1315,8 +1325,6 @@
 
     "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
     "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.36.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.36.0", "@typescript-eslint/types": "^8.36.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g=="],
 
     "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.36.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA=="],
@@ -1324,8 +1332,6 @@
     "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "eslint-config-next/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.6.2",
     "@next/eslint-plugin-next": "^15.4.4",
     "@tailwindcss/postcss": "^4.0.15",
     "@tanstack/eslint-plugin-query": "^5.83.1",
@@ -69,7 +70,6 @@
     "eslint-plugin-unicorn": "^59.0.1",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
-    "prettier-plugin-organize-imports": "^4.1.0",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4.0.15",
     "tw-animate-css": "^1.3.6",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,9 @@
 /** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
 const prettierConfig = {
-  plugins: ["prettier-plugin-tailwindcss", "prettier-plugin-organize-imports"],
+  plugins: [
+    "prettier-plugin-tailwindcss",
+    "@ianvs/prettier-plugin-sort-imports",
+  ],
   semi: true,
   singleQuote: false,
   trailingComma: "all",

--- a/src/app/dashboard/create-instance/page.tsx
+++ b/src/app/dashboard/create-instance/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Sidebar } from "@/components/Sidebar";
-import { VM } from "@/components/VM";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { VM } from "@/components/VM";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Create Instance",

--- a/src/app/dashboard/images/page.tsx
+++ b/src/app/dashboard/images/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Images } from "@/components/Images";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Images",

--- a/src/app/dashboard/instances/page.tsx
+++ b/src/app/dashboard/instances/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Instances } from "@/components/Instances";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Instances",

--- a/src/app/dashboard/migrate-vm/page.tsx
+++ b/src/app/dashboard/migrate-vm/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { ImportVM } from "@/components/ImportVM";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Import VM",

--- a/src/app/dashboard/networks/page.tsx
+++ b/src/app/dashboard/networks/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Networks } from "@/components/Networks";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Networks",

--- a/src/app/dashboard/overview/page.tsx
+++ b/src/app/dashboard/overview/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Overview } from "@/components/Overview";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Overview",

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Projects } from "@/components/Projects";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Projects",

--- a/src/app/dashboard/scale/page.tsx
+++ b/src/app/dashboard/scale/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { ScaleOperations } from "@/components/Scale";
 import { Sidebar } from "@/components/Sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Scale",

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -1,8 +1,7 @@
-import { type Metadata } from "next";
-
 import { Sidebar } from "@/components/Sidebar";
-import { UsersManager } from "@/components/Users";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { UsersManager } from "@/components/Users";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Users",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import "@/styles/globals.css";
-
 import { Providers } from "@/components/providers";
 import { type Metadata } from "next";
 import { Geist } from "next/font/google";

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,5 @@
-import { type Metadata } from "next";
-
 import Login from "@/components/Login";
+import { type Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "IConsole | Login",

--- a/src/components/DescribeVMTab.tsx
+++ b/src/components/DescribeVMTab.tsx
@@ -10,12 +10,11 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
-import { Languages, Loader2, Mic, MicOff, Send, Trash2 } from "lucide-react";
-
 import type { CreateFromDescriptionRequest } from "@/types/RequestInterfaces";
 import { CreateFromDescriptionRequestSchema } from "@/types/RequestSchemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { pipeline, read_audio } from "@huggingface/transformers";
+import { Languages, Loader2, Mic, MicOff, Send, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import SpeechRecognition, {

--- a/src/components/DetailsStep.tsx
+++ b/src/components/DetailsStep.tsx
@@ -1,6 +1,3 @@
-import { MonitorStop } from "lucide-react";
-import { type UseFormReturn } from "react-hook-form";
-
 import {
   Form,
   FormControl,
@@ -12,6 +9,8 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import type { VMDetailsFormData } from "@/types/RequestInterfaces";
+import { MonitorStop } from "lucide-react";
+import { type UseFormReturn } from "react-hook-form";
 
 export function DetailsStep({
   form,

--- a/src/components/FlavorStep.tsx
+++ b/src/components/FlavorStep.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { Cpu, HardDrive, MemoryStick } from "lucide-react";
-import { type useForm } from "react-hook-form";
-
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Form, FormField, FormItem, FormMessage } from "@/components/ui/form";
@@ -10,6 +7,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { FlavorFormData } from "@/types/RequestInterfaces";
 import type { ResourcesResponse } from "@/types/ResponseInterfaces";
+import { Cpu, HardDrive, MemoryStick } from "lucide-react";
+import { type useForm } from "react-hook-form";
 
 export function FlavorStep({
   form,

--- a/src/components/ImageStep.tsx
+++ b/src/components/ImageStep.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { GetDistroIcon } from "@/components/GetDistroIcon";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";

--- a/src/components/Images.tsx
+++ b/src/components/Images.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import { HardDrive, Plus, Search, Upload } from "lucide-react";
-import { useEffect, useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-
 import { ErrorCard } from "@/components/ErrorCard";
 import { GetDistroIcon } from "@/components/GetDistroIcon";
 import { Button } from "@/components/ui/button";
@@ -29,6 +24,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ImageService, InfraService } from "@/lib/requests";
 import { cn } from "@/lib/utils";
 import type { ResourcesResponse } from "@/types/ResponseInterfaces";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { HardDrive, Plus, Search, Upload } from "lucide-react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 interface ImportImageForm {

--- a/src/components/ImportVM.tsx
+++ b/src/components/ImportVM.tsx
@@ -1,8 +1,4 @@
 "use client";
-import { Download, Loader2, Package, Upload } from "lucide-react";
-import { useForm } from "react-hook-form";
-
-import type { ResourcesResponse } from "@/types/ResponseInterfaces";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -34,9 +30,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { InfraService } from "@/lib/requests";
 import type { ImportVMFormData } from "@/types/RequestInterfaces";
 import { importVMSchema } from "@/types/RequestSchemas";
+import type { ResourcesResponse } from "@/types/ResponseInterfaces";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Download, Loader2, Package, Upload } from "lucide-react";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { ErrorCard } from "./ErrorCard";
 

--- a/src/components/Instances.tsx
+++ b/src/components/Instances.tsx
@@ -1,5 +1,25 @@
 "use client";
 
+import { ErrorCard } from "@/components/ErrorCard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { InfraService } from "@/lib/requests";
+import { calculateAge, cn } from "@/lib/utils";
+import type { InstanceDetailsResponse } from "@/types/ResponseInterfaces";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   HardDrive,
@@ -17,29 +37,6 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-
-import { InfraService } from "@/lib/requests";
-import type { InstanceDetailsResponse } from "@/types/ResponseInterfaces";
-
-import { ErrorCard } from "@/components/ErrorCard";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-
-import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
-import { calculateAge, cn } from "@/lib/utils";
 
 function InstanceActions({
   instanceId,

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,27 +1,5 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation } from "@tanstack/react-query";
-import {
-  AlertCircle,
-  Eye,
-  EyeOff,
-  Lock,
-  LogIn,
-  Shield,
-  User,
-} from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-
-import { setCookie } from "cookies-next";
-
-import { AuthService } from "@/lib/requests";
-import { cn } from "@/lib/utils";
-import { LoginRequestSchema } from "@/types/RequestSchemas";
-
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -39,7 +17,26 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { AuthService } from "@/lib/requests";
+import { cn } from "@/lib/utils";
 import type { LoginRequest } from "@/types/RequestInterfaces";
+import { LoginRequestSchema } from "@/types/RequestSchemas";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { setCookie } from "cookies-next";
+import {
+  AlertCircle,
+  Eye,
+  EyeOff,
+  Lock,
+  LogIn,
+  Shield,
+  User,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export default function Login() {
   const [showPassword, setShowPassword] = useState(false);

--- a/src/components/Networks.tsx
+++ b/src/components/Networks.tsx
@@ -1,12 +1,5 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Network, Plus, RefreshCw, Router, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-
 import { ErrorCard } from "@/components/ErrorCard";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -56,6 +49,12 @@ import type {
   NetworkListResponse,
   RouterCreateResponse,
 } from "@/types/ResponseInterfaces";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Network, Plus, RefreshCw, Router, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function Networks() {
   const queryClient = useQueryClient();

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+import { ErrorCard } from "@/components/ErrorCard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { InfraService } from "@/lib/requests";
+import { cn } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -15,16 +23,6 @@ import {
   XCircle,
   Zap,
 } from "lucide-react";
-
-import { InfraService } from "@/lib/requests";
-import { cn } from "@/lib/utils";
-
-import { ErrorCard } from "@/components/ErrorCard";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
 
 export function Overview() {
   const { data, isLoading, error, refetch, isFetching } = useQuery({

--- a/src/components/ProjectFormDialog.tsx
+++ b/src/components/ProjectFormDialog.tsx
@@ -1,17 +1,3 @@
-import type {
-  ProjectAssignment,
-  ProjectCreateRequest,
-  ProjectUpdateRequest,
-} from "@/types/RequestInterfaces";
-import type { ProjectDetailsResponse } from "@/types/ResponseInterfaces";
-
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, UserPlus, Users, X } from "lucide-react";
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -45,7 +31,19 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { ProjectService, UserService } from "@/lib/requests";
+import type {
+  ProjectAssignment,
+  ProjectCreateRequest,
+  ProjectUpdateRequest,
+} from "@/types/RequestInterfaces";
 import { ProjectCreateRequestSchema } from "@/types/RequestSchemas";
+import type { ProjectDetailsResponse } from "@/types/ResponseInterfaces";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, UserPlus, Users, X } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function ProjectFormDialog({
   project,

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,27 +1,5 @@
 "use client";
 
-import { cn } from "@/lib/utils";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Building,
-  ChevronDown,
-  ChevronUp,
-  Edit,
-  Plus,
-  Trash2,
-  UserPlus,
-  Users,
-} from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
-
-import { ProjectService } from "@/lib/requests";
-import type {
-  ProjectDetailsResponse,
-  UserAssignment,
-  UserRole,
-} from "@/types/ResponseInterfaces";
-
 import { ErrorCard } from "@/components/ErrorCard";
 import { ProjectFormDialog } from "@/components/ProjectFormDialog";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -44,6 +22,26 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { UserManagementDialog } from "@/components/UserManagementDialog";
+import { ProjectService } from "@/lib/requests";
+import { cn } from "@/lib/utils";
+import type {
+  ProjectDetailsResponse,
+  UserAssignment,
+  UserRole,
+} from "@/types/ResponseInterfaces";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Building,
+  ChevronDown,
+  ChevronUp,
+  Edit,
+  Plus,
+  Trash2,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 
 function ProjectActions({
   project,

--- a/src/components/Scale.tsx
+++ b/src/components/Scale.tsx
@@ -1,22 +1,5 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation } from "@tanstack/react-query";
-import { Mail, PlusCircle, ServerCog } from "lucide-react";
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-
-import { ScaleService } from "@/lib/requests";
-import type {
-  ScaleNodeRequest,
-  SendTestEmailRequest,
-} from "@/types/RequestInterfaces";
-import {
-  ScaleNodeRequestSchema,
-  SendTestEmailRequestSchema,
-} from "@/types/RequestSchemas";
-
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -42,6 +25,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ScaleService } from "@/lib/requests";
+import type {
+  ScaleNodeRequest,
+  SendTestEmailRequest,
+} from "@/types/RequestInterfaces";
+import {
+  ScaleNodeRequestSchema,
+  SendTestEmailRequestSchema,
+} from "@/types/RequestSchemas";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { Mail, PlusCircle, ServerCog } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function ScaleOperations() {
   const [showNodeDialog, setShowNodeDialog] = useState(false);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,30 +1,5 @@
 "use client";
 
-import { cn } from "@/lib/utils";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { deleteCookie, setCookie } from "cookies-next";
-import {
-  ArrowRight,
-  Boxes,
-  ChevronDown,
-  Globe,
-  Image as ImageIcon,
-  LayoutDashboard,
-  LogOut,
-  Moon,
-  Plus,
-  Server,
-  Shield,
-  Sun,
-  Users as UsersIcon,
-  Zap,
-} from "lucide-react";
-
-import { useTheme } from "next-themes";
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
-
 import { Button } from "@/components/ui/button";
 import {
   Combobox,
@@ -47,32 +22,56 @@ import {
   SidebarMenuSub,
 } from "@/components/ui/sidebar";
 import { AuthService } from "@/lib/requests";
+import { cn } from "@/lib/utils";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { deleteCookie, setCookie } from "cookies-next";
+import {
+  ArrowRight,
+  ChevronDown,
+  Cpu,
+  Expand,
+  Folder,
+  Globe,
+  HardDrive,
+  Home,
+  LogOut,
+  Monitor,
+  Moon,
+  Plus,
+  Shield,
+  Sun,
+  UserCircle2,
+} from "lucide-react";
+import { useTheme } from "next-themes";
 import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
-const sidebarItems = [
+const firstSidebarItems = [
   {
     title: "Overview",
-    icon: LayoutDashboard,
+    icon: Home,
     href: "/dashboard/overview",
   },
   {
-    title: "Projects",
-    icon: Boxes,
-    href: "/dashboard/projects",
-  },
-  {
-    title: "Images",
-    icon: ImageIcon,
-    href: "/dashboard/images",
-  },
-  {
     title: "Users",
-    icon: UsersIcon,
+    icon: UserCircle2,
     href: "/dashboard/users",
+  },
+  {
+    title: "Projects",
+    icon: Folder,
+    href: "/dashboard/projects",
   },
 ] as const;
 
-const networkingItems = [
+const secondSidebarItems = [
+  {
+    title: "Images",
+    icon: HardDrive,
+    href: "/dashboard/images",
+  },
   {
     title: "Networks",
     icon: Globe,
@@ -83,7 +82,7 @@ const networkingItems = [
 const computeSubItems = [
   {
     title: "Instances",
-    icon: Server,
+    icon: Monitor,
     href: "/dashboard/instances",
   },
   {
@@ -98,7 +97,7 @@ const computeSubItems = [
   },
   {
     title: "Scaling",
-    icon: Zap,
+    icon: Expand,
     href: "/dashboard/scale",
   },
 ] as const;
@@ -302,7 +301,7 @@ export function Sidebar() {
               </Combobox>
             </SidebarMenuItem>
 
-            {sidebarItems.map((item) => {
+            {firstSidebarItems.map((item) => {
               const isActive = pathname === item.href;
               return (
                 <SidebarMenuItem key={item.href}>
@@ -348,7 +347,7 @@ export function Sidebar() {
                     computeOpen && "rounded-full",
                   )}
                 >
-                  <Server className="h-4 w-4 mr-3 flex-shrink-0" />
+                  <Cpu className="h-4 w-4 mr-3 flex-shrink-0" />
                   <span className="text-sm font-medium flex-1 truncate text-left">
                     Compute
                   </span>
@@ -395,15 +394,14 @@ export function Sidebar() {
                 </SidebarMenuSub>
               )}
             </SidebarMenuItem>
-
-            {networkingItems.map((item) => {
+            {secondSidebarItems.map((item) => {
               const isActive = pathname === item.href;
               return (
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton
                     asChild
                     className={cn(
-                      "w-full h-10 px-3 hover:bg-accent hover:text-accent-foreground rounded-md group hover:rounded-full focus:rounded-full active:rounded-full transition-all",
+                      "w-full h-10 px-3 hover:bg-accent hover:text-accent-foreground rounded-md hover:rounded-full focus:rounded-full active:rounded-full transition-all",
                       isActive && "rounded-full",
                     )}
                   >

--- a/src/components/SummaryStep.tsx
+++ b/src/components/SummaryStep.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -13,6 +14,7 @@ import {
   Settings,
   Zap,
 } from "lucide-react";
+
 export function SummaryStep({
   data,
   resources,

--- a/src/components/UserCreateForm.tsx
+++ b/src/components/UserCreateForm.tsx
@@ -1,19 +1,5 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Plus, Shield, User } from "lucide-react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-
-import { AuthService, UserService } from "@/lib/requests";
-import type { UserCreateRequest } from "@/types/RequestInterfaces";
-import { UserCreateRequestSchema } from "@/types/RequestSchemas";
-import type {
-  ProjectsResponse,
-  RolesResponse,
-} from "@/types/ResponseInterfaces";
-
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -35,6 +21,18 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { AuthService, UserService } from "@/lib/requests";
+import type { UserCreateRequest } from "@/types/RequestInterfaces";
+import { UserCreateRequestSchema } from "@/types/RequestSchemas";
+import type {
+  ProjectsResponse,
+  RolesResponse,
+} from "@/types/ResponseInterfaces";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Plus, Shield, User } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 interface UserCreateFormProps {
   onBack: () => void;

--- a/src/components/UserEditForm.tsx
+++ b/src/components/UserEditForm.tsx
@@ -1,21 +1,5 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Plus, Save, Shield, User, X } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
-import { toast } from "sonner";
-
-import { AuthService, UserService } from "@/lib/requests";
-import type { UserUpdateRequest } from "@/types/RequestInterfaces";
-import { UserUpdateRequestSchema } from "@/types/RequestSchemas";
-import type {
-  ProjectsResponse,
-  RolesResponse,
-  UserDetailsResponse,
-} from "@/types/ResponseInterfaces";
-
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -44,6 +28,20 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { AuthService, UserService } from "@/lib/requests";
+import type { UserUpdateRequest } from "@/types/RequestInterfaces";
+import { UserUpdateRequestSchema } from "@/types/RequestSchemas";
+import type {
+  ProjectsResponse,
+  RolesResponse,
+  UserDetailsResponse,
+} from "@/types/ResponseInterfaces";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Plus, Save, Shield, User, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 interface UserEditFormProps {
   userId: string;

--- a/src/components/Users.tsx
+++ b/src/components/Users.tsx
@@ -1,28 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  AtSign,
-  Building,
-  Edit,
-  Plus,
-  RefreshCw,
-  Trash2,
-  User,
-  UserCheck,
-} from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
-
-import { UserService } from "@/lib/requests";
-import type {
-  UserDeleteResponse,
-  UserListResponse,
-} from "@/types/ResponseInterfaces";
-
 import { ErrorCard } from "@/components/ErrorCard";
-import { UserCreateForm } from "@/components/UserCreateForm";
-import { UserEditForm } from "@/components/UserEditForm";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -40,7 +18,27 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UserCreateForm } from "@/components/UserCreateForm";
+import { UserEditForm } from "@/components/UserEditForm";
+import { UserService } from "@/lib/requests";
 import { cn } from "@/lib/utils";
+import type {
+  UserDeleteResponse,
+  UserListResponse,
+} from "@/types/ResponseInterfaces";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AtSign,
+  Building,
+  Edit,
+  Plus,
+  RefreshCw,
+  Trash2,
+  User,
+  UserCheck,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 
 type ViewMode = "list" | "create" | "edit";
 

--- a/src/components/VM.tsx
+++ b/src/components/VM.tsx
@@ -1,5 +1,37 @@
 "use client";
 
+import { DescribeVMTab } from "@/components/DescribeVMTab";
+import { DetailsStep } from "@/components/DetailsStep";
+import { ErrorCard } from "@/components/ErrorCard";
+import { FlavorStep } from "@/components/FlavorStep";
+import { ImageStep } from "@/components/ImageStep";
+import { NetworkStep } from "@/components/NetworkStep";
+import { SummaryStep } from "@/components/SummaryStep";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { InfraService } from "@/lib/requests";
+import { cn } from "@/lib/utils";
+import type {
+  CombinedVMData,
+  FlavorFormData,
+  ImageFormData,
+  NetworkFormData,
+  VMCreateRequest,
+  VMDetailsFormData,
+} from "@/types/RequestInterfaces";
+import {
+  flavorSchema,
+  imageSchema,
+  networkSchema,
+  vmDetailsSchema,
+} from "@/types/RequestSchemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -17,40 +49,6 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
-import { DescribeVMTab } from "@/components/DescribeVMTab";
-import { DetailsStep } from "@/components/DetailsStep";
-import { ErrorCard } from "@/components/ErrorCard";
-import { FlavorStep } from "@/components/FlavorStep";
-import { ImageStep } from "@/components/ImageStep";
-import { NetworkStep } from "@/components/NetworkStep";
-import { SummaryStep } from "@/components/SummaryStep";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-
-import { Separator } from "@/components/ui/separator";
-import { InfraService } from "@/lib/requests";
-import type {
-  CombinedVMData,
-  FlavorFormData,
-  ImageFormData,
-  NetworkFormData,
-  VMCreateRequest,
-  VMDetailsFormData,
-} from "@/types/RequestInterfaces";
-import {
-  flavorSchema,
-  imageSchema,
-  networkSchema,
-  vmDetailsSchema,
-} from "@/types/RequestSchemas";
-
-import { cn } from "@/lib/utils";
 type WizardStep = "flavor" | "image" | "network" | "details" | "summary";
 export function VM() {
   const [activeTab, setActiveTab] = useState<"create" | "describe" | undefined>(

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
-
-import { TooltipProvider } from "@/components/ui/tooltip";
 
 const queryClient = new QueryClient();
 

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Avatar({
   className,

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,8 +1,7 @@
+import { cn } from "@/lib/utils";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,7 @@
+import { cn } from "@/lib/utils";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import { cn } from "@/lib/utils";
+import * as React from "react";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Checkbox({
   className,

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -19,13 +19,13 @@ import { cn } from "@/lib/utils";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { ChevronsUpDownIcon, PlusIcon } from "lucide-react";
 import {
-  type ComponentProps,
   createContext,
-  type ReactNode,
   useContext,
   useEffect,
   useRef,
   useState,
+  type ComponentProps,
+  type ReactNode,
 } from "react";
 
 type ComboboxData = {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { Command as CommandPrimitive } from "cmdk";
-import { SearchIcon } from "lucide-react";
-import * as React from "react";
-
 import {
   Dialog,
   DialogContent,
@@ -12,6 +8,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+import * as React from "react";
 
 function Command({
   className,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Dialog({
   ...props

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
@@ -12,9 +14,6 @@ import {
   type FieldPath,
   type FieldValues,
 } from "react-hook-form";
-
-import { Label } from "@/components/ui/label";
-import { cn } from "@/lib/utils";
 
 const Form = FormProvider;
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import { cn } from "@/lib/utils";
+import * as React from "react";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Label({
   className,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Popover({
   ...props

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Select({
   ...props

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Separator({
   className,

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
-import * as React from "react";
-
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -24,6 +19,10 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+import * as React from "react";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import { cn } from "@/lib/utils";
+import * as React from "react";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 function TooltipProvider({
   delayDuration = 0,


### PR DESCRIPTION
### TL;DR

Replace `prettier-plugin-organize-imports` with `@ianvs/prettier-plugin-sort-imports` for better import organization and standardize import ordering across the codebase.

### What changed?

- Replaced `prettier-plugin-organize-imports` with `@ianvs/prettier-plugin-sort-imports` in package dependencies
- Updated the Prettier configuration to use the new plugin
- Reorganized imports across all components to follow a consistent pattern:
  - Internal components and UI elements first
  - Local utilities and types next
  - External dependencies last
  - Organized imports alphabetically within each group

### Why make this change?

The `@ianvs/prettier-plugin-sort-imports` plugin provides more advanced import sorting capabilities than the previous plugin, allowing for better organization of imports by category (internal vs external). This improves code readability and maintainability by establishing a consistent import pattern across the entire codebase, making it easier to understand dependencies and relationships between components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated sidebar navigation: added Users and Images, removed Networking items, regrouped sections, and refreshed icons (e.g., Monitor for Instances, Expand for Scaling) for clearer navigation.

- Style
  - Standardized import ordering and minor formatting across the app with no functional changes.

- Chores
  - Switched code formatting plugin to a new import-sorting tool to maintain consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->