### PR TITLE
removed comment eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,8 +33,6 @@ export default defineConfig(
       "jsx-a11y": jsxA11yPlugin,
       unicorn: unicornPlugin,
       prettier: prettierPlugin,
-      // @ts-expect-error - TanStack Query plugin has type compatibility issues with new ESLint types
-      "@tanstack/query": pluginQuery,
     },
     rules: {
       "@typescript-eslint/array-type": "off",


### PR DESCRIPTION
### TL;DR

Remove the TanStack Query ESLint plugin from the configuration.

### What changed?

Removed the TanStack Query plugin (`@tanstack/query`) from the ESLint configuration. The plugin was previously included with a TypeScript expect-error comment due to type compatibility issues with new ESLint types.

### Why make this change?

The TanStack Query plugin was causing type compatibility issues with the newer ESLint types, as indicated by the removed comment. Removing this plugin simplifies the ESLint configuration and eliminates the need for type assertion workarounds, while maintaining the core linting functionality.