### PR TITLE
attempting to fix project user assignment

### DIFF
--- a/src/components/Projects/ProjectForm.tsx
+++ b/src/components/Projects/ProjectForm.tsx
@@ -308,7 +308,7 @@ export function ProjectForm({
               </div>
 
               {/* Show user assignments section only when editing */}
-              {isEditing && (
+              {!isEditing && (
                 <>
                   <Separator />
                   <div className="space-y-4">

--- a/src/components/Projects/UserManagementDialog.tsx
+++ b/src/components/Projects/UserManagementDialog.tsx
@@ -364,7 +364,7 @@ export function UserManagementDialog({
                           });
                           setPendingRoleIds(
                             (assignment.roles ?? []).map(
-                              (role) => role.role_id,
+                              (role) => role.role_name,
                             ),
                           );
                         }}

--- a/src/components/Users/UserCreateForm.tsx
+++ b/src/components/Users/UserCreateForm.tsx
@@ -27,12 +27,13 @@ import { ArrowLeft, Plus, Shield, User } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
-interface UserCreateFormProps {
+export function UserCreateForm({
+  onBack,
+  onSuccess,
+}: {
   onBack: () => void;
   onSuccess: () => void;
-}
-
-export function UserCreateForm({ onBack, onSuccess }: UserCreateFormProps) {
+}) {
   const queryClient = useQueryClient();
 
   const form = useForm<UserCreateRequest>({


### PR DESCRIPTION
### TL;DR

Fixed user assignment logic in project forms and corrected role mapping in user management.

### What changed?

- Inverted the condition for displaying user assignments in `ProjectForm.tsx` from `isEditing` to `!isEditing`
- Fixed the role mapping in `UserManagementDialog.tsx` to use `role_name` instead of `role_id`
- Simplified the `UserCreateForm.tsx` component by removing the redundant interface declaration and using inline props typing

### Why make this change?

The user assignment section was incorrectly showing only when editing projects, but the intended behavior is to show it when creating new projects. Additionally, the role mapping was using the wrong property, causing potential issues with role assignments. The code structure in `UserCreateForm` was also simplified for better maintainability.