### PR TITLE
fixed images editing and keypair creation

### DIFF
--- a/src/components/Images/ImageEditDialog.tsx
+++ b/src/components/Images/ImageEditDialog.tsx
@@ -73,38 +73,32 @@ export function ImageEditDialog({
   const onSubmit = form.handleSubmit((values) => {
     if (!imageId) return;
 
-    const dirtyFields = form.formState.dirtyFields;
     const updateData: Partial<ImageUpdateRequest> = {};
 
-    if (dirtyFields.new_name && values.new_name?.trim()) {
-      updateData.new_name = values.new_name.trim();
+    if (values.new_name !== undefined) {
+      updateData.new_name = values.new_name;
     }
 
-    if (dirtyFields.visibility && values.visibility) {
+    if (values.visibility !== undefined) {
       updateData.visibility = values.visibility;
     }
 
-    if (dirtyFields.protected !== undefined) {
+    if (values.protected !== undefined) {
       updateData.protected = values.protected;
-    }
-
-    if (Object.keys(updateData).length === 0) {
-      onOpenChange(false);
-      return;
     }
 
     mutation.mutate(updateData as ImageUpdateRequest);
   });
 
   useEffect(() => {
-    if (initialData) {
+    if (initialData && imageId) {
       form.reset({
         new_name: initialData.name,
         visibility: initialData.visibility,
         protected: initialData.protected,
       });
     }
-  }, [initialData, form]);
+  }, [initialData, imageId, form]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -203,9 +197,7 @@ export function ImageEditDialog({
               <Button
                 type="submit"
                 variant="default"
-                disabled={
-                  mutation.isPending || !imageId || !form.formState.isDirty
-                }
+                disabled={mutation.isPending || !imageId}
                 className="order-1 w-full min-w-[140px] cursor-pointer gap-2 rounded-full sm:order-2 sm:w-auto"
               >
                 {mutation.isPending ? (

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1795,9 +1795,11 @@ export const KeyPairService = {
   async create(data: KeyPairCreateRequest): Promise<KeyPairCreateResponse> {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
+
+    const params = createSearchParams(data);
     const result = await client.post<KeyPairCreateResponse>(
-      API_CONFIG.BASE_URL + API_CONFIG.KEYPAIRS.CREATE,
-      { type: "json", data },
+      `${API_CONFIG.BASE_URL}${API_CONFIG.KEYPAIRS.CREATE}?${params.toString()}`,
+      { type: "json", data: {} },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);


### PR DESCRIPTION
### TL;DR

Improved image editing functionality and fixed keypair creation API request format.

### What changed?

- Simplified the `ImageEditDialog` component by removing unnecessary checks for dirty fields
- Fixed the image edit form to properly submit all values regardless of whether they were changed
- Removed the condition that prevented submission when no fields were changed
- Added `imageId` dependency to the `useEffect` hook to ensure proper form reset
- Removed the `isDirty` check from the submit button's disabled state
- Updated the `KeyPairService.create` method to send parameters as URL query params instead of in the request body

### Why make this change?

The previous implementation had unnecessary complexity in the image editing form that could prevent valid submissions. The keypair creation API expects parameters in the URL query string rather than the request body, so this change aligns the client with the API's requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Image editing dialog now reliably applies updates for provided fields and avoids unintended resets when switching images.
  - Submit button state is more accurate, only disabling when saving is in progress or no image is selected.
  - Improved reliability of key pair creation by adjusting how request parameters are sent.

- Chores
  - Internal request handling streamlined for key pair creation to align with backend expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->