### PR TITLE
fixed extend volume

### DIFF
--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1442,8 +1442,8 @@ export const VolumeService = {
     if (!token.Authorization) throw new Error("Token not found");
     const result = await client.put<VolumeActionResponse>(
       API_CONFIG.BASE_URL +
-        `${API_CONFIG.VOLUME.BASE}/${data.volume_id}/extend`,
-      { type: "json", data },
+        `${API_CONFIG.VOLUME.BASE}/${data.volume_id}/extend?new_size=${data.new_size}`,
+      { type: "json", data: {} },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);


### PR DESCRIPTION
### TL;DR

Updated the volume extend API request to use query parameters instead of request body.

### What changed?

Modified the `extend` method in `VolumeService` to:
- Move the `new_size` parameter from the request body to a query parameter in the URL
- Set the request body to an empty object (`{}`) since the data is now passed via URL

### Why make this change?

This change aligns the API request format with the backend expectations, which requires the `new_size` parameter to be passed as a query parameter rather than in the request body. This ensures proper communication with the API endpoint for volume extension operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of volume resize requests with the backend by adjusting how the requested size is transmitted.
  * Resolves intermittent failures when extending volumes, ensuring more consistent behavior across environments.
  * No UI changes; existing workflows for resizing volumes remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->