### PR TITLE
fixed extend volume

### DIFF
--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1440,7 +1440,7 @@ export const VolumeService = {
   async extend(data: VolumeExtendRequest): Promise<VolumeActionResponse> {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
-    const result = await client.put<VolumeActionResponse>(
+    const result = await client.post<VolumeActionResponse>(
       API_CONFIG.BASE_URL +
         `${API_CONFIG.VOLUME.BASE}/${data.volume_id}/extend?new_size=${data.new_size}`,
       { type: "json", data: {} },


### PR DESCRIPTION
### TL;DR

Changed the HTTP method from PUT to POST in the Volume extend API call.

### What changed?

Modified the `extend` method in the `VolumeService` to use `client.post` instead of `client.put` when making the API call to extend a volume's size.

### Why make this change?

The API endpoint for extending volumes expects POST requests rather than PUT requests. This change aligns our client implementation with the server's API requirements, ensuring proper communication between the client and server for volume extension operations.