### PR TITLE
fixed upload image volume service

### DIFF
--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1494,10 +1494,13 @@ export const VolumeService = {
   ): Promise<VolumeActionResponse> {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
+    const { volume_id, ...queryData } = data;
+    const params = createSearchParams(queryData);
+
     const result = await client.post<VolumeActionResponse>(
       API_CONFIG.BASE_URL +
-        `${API_CONFIG.VOLUME.BASE}/${data.volume_id}/upload-to-image`,
-      { type: "json", data },
+        `${API_CONFIG.VOLUME.BASE}/${data.volume_id}/upload-to-image?${params.toString()}`,
+      { type: "json", data: {} },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);
@@ -1645,9 +1648,13 @@ export const VolumeService = {
   async createVolumeType(data: VolumeTypeCreateRequest): Promise<VolumeType> {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
+
+    const params = createSearchParams(data);
     const result = await client.post<VolumeType>(
-      API_CONFIG.BASE_URL + API_CONFIG.VOLUME.TYPES_CREATE,
-      { type: "json", data },
+      API_CONFIG.BASE_URL +
+        API_CONFIG.VOLUME.TYPES_CREATE +
+        `?${params.toString()}`,
+      { type: "json", data: {} },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);


### PR DESCRIPTION
### TL;DR

Updated volume API requests to use URL query parameters instead of request body.

### What changed?

- Modified `VolumeService.uploadToImage` to extract `volume_id` from the data and convert the remaining properties to URL query parameters
- Updated `VolumeService.createVolumeType` to convert all data to URL query parameters
- Both methods now send an empty object `{}` in the request body instead of the data

### Why make this change?

This change aligns the API request format with backend expectations, ensuring that parameters are passed in the URL rather than the request body. This is likely required by the API endpoints that expect query parameters instead of JSON body data for these specific operations.