### PR TITLE
always fixed2

### DIFF
--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1729,9 +1729,11 @@ export const SecurityGroupService = {
   ): Promise<SecurityGroupCreateResponse> {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
+
+    const params = createSearchParams(data);
     const result = await client.post<SecurityGroupCreateResponse>(
-      API_CONFIG.BASE_URL + API_CONFIG.SECURITY_GROUP.BASE,
-      { type: "json", data },
+      `${API_CONFIG.BASE_URL}${API_CONFIG.SECURITY_GROUP.BASE}?${params.toString()}`,
+      { type: "json", data: {} },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);
@@ -1771,10 +1773,11 @@ export const SecurityGroupService = {
   ): Promise<SecurityGroupRuleCreateResponse> {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
+
+    const params = createSearchParams(data);
     const result = await client.post<SecurityGroupRuleCreateResponse>(
-      API_CONFIG.BASE_URL +
-        `${API_CONFIG.SECURITY_GROUP.RULES}${securityGroupId}/rules`,
-      { type: "json", data },
+      `${API_CONFIG.BASE_URL}${API_CONFIG.SECURITY_GROUP.RULES}${securityGroupId}/rules?${params.toString()}`,
+      { type: "json", data: {} },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);


### PR DESCRIPTION
### TL;DR

Updated security group API requests to use query parameters instead of request body.

### What changed?

Modified the `SecurityGroupService.create` and `SecurityGroupService.createRule` methods to:
- Move request data from the request body to URL query parameters
- Use `createSearchParams` to properly format the parameters
- Send an empty object `{}` as the request body data
- Format the URL using template literals for better readability

### How to test?

1. Create a new security group using the SecurityGroupService.create method
2. Create a new security group rule using the SecurityGroupService.createRule method
3. Verify that both requests are successful and the data is properly sent as query parameters

### Why make this change?

The API endpoints for security group operations expect parameters in the URL query string rather than in the request body. This change aligns our client implementation with the API's expected request format, ensuring proper communication with the backend services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved failures when creating security groups or adding rules by correcting request formatting, improving compatibility with the backend.
  * Enhanced reliability of create and add-rule operations to ensure submissions complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->