### PR TITLE
cluster stop start fix

### DIFF
--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1937,8 +1937,8 @@ export const ClusterService = {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
     const result = await client.post<ClusterActionResponse>(
-      API_CONFIG.BASE_URL + `${API_CONFIG.CLUSTER.START}/${data.cluster_id}`,
-      { type: "json", data: {} },
+      API_CONFIG.BASE_URL + API_CONFIG.CLUSTER.START,
+      { type: "json", data },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);
@@ -1949,8 +1949,8 @@ export const ClusterService = {
     const token = authHeaders();
     if (!token.Authorization) throw new Error("Token not found");
     const result = await client.post<ClusterActionResponse>(
-      API_CONFIG.BASE_URL + `${API_CONFIG.CLUSTER.STOP}/${data.cluster_id}`,
-      { type: "json", data: {} },
+      API_CONFIG.BASE_URL + API_CONFIG.CLUSTER.STOP,
+      { type: "json", data },
       { headers: token },
     );
     if (result.error) throw new Error(result.error.message);


### PR DESCRIPTION
### TL;DR

Fixed cluster start and stop API requests by updating endpoint URLs and properly passing data parameters.

### What changed?

- Modified the `ClusterService.start` method to:
    - Use the base cluster start endpoint without appending the cluster_id
    - Pass the full data object in the request body instead of an empty object
- Made the same changes to the `ClusterService.stop` method:
    - Use the base cluster stop endpoint without appending the cluster_id
    - Pass the full data object in the request body instead of an empty object

### Why make this change?

The previous implementation was incorrectly appending the cluster_id to the endpoint URL while sending an empty data object in the request body. The API expects the cluster_id to be part of the request body data instead. This change aligns the client requests with the API's expected format, ensuring proper functionality of cluster start and stop operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
    - Standardized request handling for cluster start/stop actions using a unified endpoint and sending details in the request body. This streamlines processing, reduces inconsistencies across environments, and keeps existing error handling intact. No changes to user workflows or visible behavior are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->