### PR TITLE
fixed routes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,8 +7,10 @@ export function middleware(request: NextRequest) {
   const isLoggedIn = !!(user && token);
 
   const protectedRoutes = [
+    "/dashboard/cicd-deployment",
     "/dashboard/clusters",
     "/dashboard/flavors",
+    "/dashboard/floating-ips",
     "/dashboard/images",
     "/dashboard/instances",
     "/dashboard/keypairs",
@@ -16,6 +18,7 @@ export function middleware(request: NextRequest) {
     "/dashboard/networks",
     "/dashboard/overview",
     "/dashboard/projects",
+    "/dashboard/routers",
     "/dashboard/scale",
     "/dashboard/security-groups",
     "/dashboard/snapshots",


### PR DESCRIPTION
### TL;DR

Added new protected routes to the middleware authentication check.

### What changed?

Added three new routes to the protected routes array in the middleware:
- `/dashboard/cicd-deployment`
- `/dashboard/floating-ips`
- `/dashboard/routers`

These routes now require user authentication like the other dashboard routes.

### Why make this change?

These new dashboard routes contain sensitive information and functionality that should only be accessible to authenticated users, maintaining consistent security across all dashboard pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded protected dashboard areas to include CICD Deployment, Floating IPs, and Routers pages. Unauthenticated users will be redirected to sign in; authenticated users retain normal access. Bookmarks and direct links to these pages now follow the same sign-in requirement as other protected sections. No other behavior changes. Existing session handling and redirects remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->